### PR TITLE
Update moveit-tutorial_ja_robot-simulator.md

### DIFF
--- a/doc/moveit-tutorial_ja_robot-simulator.md
+++ b/doc/moveit-tutorial_ja_robot-simulator.md
@@ -91,7 +91,7 @@ $ sudo apt-get install ros-indigo-baxter-simulator
 
 　インストール方法については以下の公式ページにも説明があるので参照ください．このページから該当部分をコピーペーストすると上記のコマンドを打たなくても良くなります．
  - [http://sdk.rethinkrobotics.com/wiki/Workstation_Setup](http://sdk.rethinkrobotics.com/wiki/Workstation_Setup)
- - [http://sdk.rethinkrobotics.com/wiki/Workstation_Setup](http://sdk.rethinkrobotics.com/wiki/Simulator_Installation) 
+ - [http://sdk.rethinkrobotics.com/wiki/Simulator_Installation](http://sdk.rethinkrobotics.com/wiki/Simulator_Installation) 
 
 ### MINAS TRA1 シミュレータのインストール
 


### PR DESCRIPTION
【B】
https://github.com/tork-a/tork_moveit_tutorial/blob/indigo-devel/doc/moveit-tutorial_ja_robot-simulator.md
Baxter ソフトウェアのインストール　節の二つ目のリンクの文字列
×http://sdk.rethinkrobotics.com/wiki/Workstation_Setup
○http://sdk.rethinkrobotics.com/wiki/Simulator_Installation

Fixes #16